### PR TITLE
 [Fuzzer] Fix more rust dependencies

### DIFF
--- a/BOOM/docker/install-fuzzer.sh
+++ b/BOOM/docker/install-fuzzer.sh
@@ -27,6 +27,8 @@ cargo update -p postcard@1.1.3 --precise 1.1.1
 cargo update -p uuid --precise 1.3.0
 #cargo update -p getrandom@0.4.2 --precise 0.3.4
 
+cargo update -p unicode-segmentation@1.13.2 --precise 1.12.0
+
 
 cargo build --release
 cargo build

--- a/BOOM/docker/install-fuzzer.sh
+++ b/BOOM/docker/install-fuzzer.sh
@@ -24,5 +24,9 @@ source "$HOME/.cargo/env"
 cargo update -p postcard@1.1.3 --precise 1.1.1
 #cargo update -p backtrace@0.3.75 --precise 0.3.68
 
+cargo update -p uuid --precise 1.3.0
+#cargo update -p getrandom@0.4.2 --precise 0.3.4
+
+
 cargo build --release
 cargo build


### PR DESCRIPTION
The list did in fact grow.

The newest version of uuid requires a getrandom version 0.4.2, which is not compatible with the rust version being used
This downgrade of uuid might be overly aggressive, but it works.

Then just now while double checking that the fix does in fact work, I realized unicode_segmentation is now also running into this problem and so have added it to the list.